### PR TITLE
Add UUID type to _to_sql_value()

### DIFF
--- a/pgmock/exceptions.py
+++ b/pgmock/exceptions.py
@@ -233,7 +233,7 @@ class ValueSerializationError(Error):
     """Thrown when a Python value cannot be serialized to a postgres ``VALUES`` value.
 
     pgmock supports serializing the following Python types: bool, float,
-    int, str, dict (json), datetime, date, time (all time types support timezones).
+    int, str, dict (json), UUID, datetime, date, time (all time types support timezones).
 
     If the python type being serialized doesn't match, one must supply
     a column type hint when patching values. Open an issue on pgmock or contact

--- a/pgmock/render.py
+++ b/pgmock/render.py
@@ -10,6 +10,7 @@ import datetime as dt
 import functools
 import json
 import re
+import uuid
 
 import sqlalchemy as sqla
 
@@ -197,12 +198,14 @@ def _to_sql_value(val, col_type=None):
         dt.datetime: lambda v: "'%s'" % v.isoformat(),
         dt.date: lambda v: "'%s'" % v.isoformat(),
         dt.time: lambda v: "'%s'" % v.isoformat(),
+        uuid.UUID: lambda v: "'%s'" % str(v).replace("'", "''"),
     }
     PG_TYPES = {
         dict: lambda v: 'JSON',
         dt.datetime: lambda v: 'TIMESTAMP%s' % ('TZ' if v.tzinfo else ''),
         dt.date: lambda v: 'DATE',
         dt.time: lambda v: 'TIME%s' % ('TZ' if v.tzinfo else ''),
+        uuid.UUID: lambda v: 'UUID'
     }
     if not col_type and val.__class__ in PG_TYPES:
         col_type = PG_TYPES[val.__class__](val)

--- a/pgmock/render.py
+++ b/pgmock/render.py
@@ -198,7 +198,7 @@ def _to_sql_value(val, col_type=None):
         dt.datetime: lambda v: "'%s'" % v.isoformat(),
         dt.date: lambda v: "'%s'" % v.isoformat(),
         dt.time: lambda v: "'%s'" % v.isoformat(),
-        uuid.UUID: lambda v: "'%s'" % str(v).replace("'", "''"),
+        uuid.UUID: lambda v: "'%s'" % str(v),
     }
     PG_TYPES = {
         dict: lambda v: 'JSON',

--- a/pgmock/tests/test_render.py
+++ b/pgmock/tests/test_render.py
@@ -8,7 +8,7 @@ import pytest_pgsql
 import pgmock.exceptions
 import pgmock.render
 
-TEST_UUID_STR = '754b2b75-96fb-4fcd-b719-adfe7ab45f11'  # nophi
+TEST_UUID_STR = '754b2b75-96fb-4fcd-b719-adfe7ab45f11'
 
 
 @pytest.mark.parametrize('rows, expected', [

--- a/pgmock/tests/test_render.py
+++ b/pgmock/tests/test_render.py
@@ -1,4 +1,5 @@
 """Unit tests for the pgmock.render module"""
+import uuid
 import datetime as dt
 
 import pytest
@@ -6,6 +7,8 @@ import pytest_pgsql
 
 import pgmock.exceptions
 import pgmock.render
+
+TEST_UUID_STR = '754b2b75-96fb-4fcd-b719-adfe7ab45f11'  # nophi
 
 
 @pytest.mark.parametrize('rows, expected', [
@@ -20,6 +23,7 @@ import pgmock.render
     ([(True, False)], "VALUES (TRUE,FALSE)"),
     ([({'my': 'json'},)], "VALUES ('{\"my\": \"json\"}'::JSON)"),
     ([({"my": "quo'te"},)], "VALUES ('{\"my\": \"quo''te\"}'::JSON)"),
+    ([(uuid.UUID(TEST_UUID_STR),)], f"VALUES ('{TEST_UUID_STR}'::UUID)"),
     pytest.mark.xfail(([(object(),)], None), raises=pgmock.exceptions.ValueSerializationError)
 ])
 def test_gen_values_list(rows, expected):

--- a/pgmock/tests/test_render.py
+++ b/pgmock/tests/test_render.py
@@ -23,7 +23,7 @@ TEST_UUID_STR = '754b2b75-96fb-4fcd-b719-adfe7ab45f11'  # nophi
     ([(True, False)], "VALUES (TRUE,FALSE)"),
     ([({'my': 'json'},)], "VALUES ('{\"my\": \"json\"}'::JSON)"),
     ([({"my": "quo'te"},)], "VALUES ('{\"my\": \"quo''te\"}'::JSON)"),
-    ([(uuid.UUID(TEST_UUID_STR),)], f"VALUES ('{TEST_UUID_STR}'::UUID)"),
+    ([(uuid.UUID(TEST_UUID_STR),)], "VALUES ('{}'::UUID)".format(TEST_UUID_STR)),
     pytest.mark.xfail(([(object(),)], None), raises=pgmock.exceptions.ValueSerializationError)
 ])
 def test_gen_values_list(rows, expected):


### PR DESCRIPTION
* Add `UUID` type to `_to_sql_value()`. 
* Add test to `test_render.py` to check function.

Added to allow for [generation of VALUES lists containing UUID elements](https://pgmock.readthedocs.io/en/latest/exceptions.html#pgmock.exceptions.ValueSerializationError).