### PR TITLE
Fix column name of preversed keywords causes syntax error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,10 +50,6 @@ jobs:
       - run:
           <<: *dependencies
       - run: make validate
-  test_py34:
-    docker:
-      - image: circleci/python:3.4-stretch
-    <<: *test_boilerplate
   test_py35:
     docker:
       - image: circleci/python:3.5-stretch
@@ -91,7 +87,6 @@ workflows:
     jobs:
       - temple_check
       - lint
-      - test_py34
       - test_py35
       - test_py36
       - test_py37
@@ -99,7 +94,6 @@ workflows:
           requires:
             - temple_check
             - lint
-            - test_py34
             - test_py35
             - test_py36
             - test_py37

--- a/Makefile
+++ b/Makefile
@@ -71,12 +71,12 @@ endif
 	#
 	# If you don't have these installed yet it's going to take a long time, but
 	# you'll only need to do it once.
+	pyenv install -s 3.7.7
 	pyenv install -s 3.6.2
 	pyenv install -s 3.5.3
-	pyenv install -s 3.4.4
 
 	# Set up the dev env and the environments for Tox
-	pyenv local ${MODULE_NAME} 3.6.2 3.5.3 3.4.4
+	pyenv local ${MODULE_NAME} 3.7.7 3.6.2 3.5.3 
 
 
 # Deactivates pyenv and removes it from auto-using the virtualenv

--- a/pgmock/render.py
+++ b/pgmock/render.py
@@ -306,7 +306,7 @@ def _gen_values(rows, cols=None, alias=None, select_all_from=False):
         values += ' LIMIT 0'
     if alias:
         # escape all, in order to avoid hitting reserved keywords
-        escaped_col_names = [f'"{col}"' for col in col_names]
+        escaped_col_names = ['"%s"' % (col) for col in col_names]
         values = '(%s) AS %s(%s)' % (values, alias, ','.join(escaped_col_names))
     if select_all_from:
         values = 'SELECT * FROM %s' % values

--- a/pgmock/render.py
+++ b/pgmock/render.py
@@ -305,7 +305,9 @@ def _gen_values(rows, cols=None, alias=None, select_all_from=False):
     if empty_values:
         values += ' LIMIT 0'
     if alias:
-        values = '(%s) AS %s(%s)' % (values, alias, ','.join(col_names))
+        # escape all, in order to avoid hitting reserved keywords
+        escaped_col_names = [f'"{col}"' for col in col_names]
+        values = '(%s) AS %s(%s)' % (values, alias, ','.join(escaped_col_names))
     if select_all_from:
         values = 'SELECT * FROM %s' % values
 

--- a/pgmock/tests/test_examples.py
+++ b/pgmock/tests/test_examples.py
@@ -41,7 +41,9 @@ def test_patch_subquery_from_file(transacted_postgresql_db, tmpdir):
         rows=[('v1', 'v2'), ('v3', 'v4')],
         cols=['c1', 'c2']
     ))
-    assert patched == "SELECT * FROM  (VALUES ('v1','v2'),('v3','v4')) AS test_table(\"c1\",\"c2\")"
+    assert (
+        patched == "SELECT * FROM  (VALUES ('v1','v2'),('v3','v4')) AS test_table(\"c1\",\"c2\")"
+    )
 
     # Patches can also be applied with list of dictionaries, filling in only what's needed.
     # Column names must still be provided. null values will be filled for all missing columns
@@ -50,7 +52,9 @@ def test_patch_subquery_from_file(transacted_postgresql_db, tmpdir):
         rows=[{'c1': 'v1'}, {'c2': 'v4'}],
         cols=['c1', 'c2']
     ))
-    assert patched == "SELECT * FROM  (VALUES ('v1',null),(null,'v4')) AS test_table(\"c1\",\"c2\")"
+    assert (
+        patched == "SELECT * FROM  (VALUES ('v1',null),(null,'v4')) AS test_table(\"c1\",\"c2\")"
+    )
 
     results = list(transacted_postgresql_db.connection.execute(patched))
     assert results == [('v1', None), (None, 'v4')]

--- a/pgmock/tests/test_examples.py
+++ b/pgmock/tests/test_examples.py
@@ -38,19 +38,19 @@ def test_patch_subquery_from_file(transacted_postgresql_db, tmpdir):
     # Patch the table of the subquery and verify it returns the proper results
     patched = pgmock.sql(subquery, pgmock.patch(
         pgmock.table('test_table'),
-        [('v1', 'v2'), ('v3', 'v4')],
-        ['c1', 'c2']
+        rows=[('v1', 'v2'), ('v3', 'v4')],
+        cols=['c1', 'c2']
     ))
-    assert patched == "SELECT * FROM  (VALUES ('v1','v2'),('v3','v4')) AS test_table(c1,c2)"
+    assert patched == "SELECT * FROM  (VALUES ('v1','v2'),('v3','v4')) AS test_table(\"c1\",\"c2\")"
 
     # Patches can also be applied with list of dictionaries, filling in only what's needed.
     # Column names must still be provided. null values will be filled for all missing columns
     patched = pgmock.sql(subquery, pgmock.patch(
         pgmock.table('test_table'),
-        [{'c1': 'v1'}, {'c2': 'v4'}],
-        ['c1', 'c2']
+        rows=[{'c1': 'v1'}, {'c2': 'v4'}],
+        cols=['c1', 'c2']
     ))
-    assert patched == "SELECT * FROM  (VALUES ('v1',null),(null,'v4')) AS test_table(c1,c2)"
+    assert patched == "SELECT * FROM  (VALUES ('v1',null),(null,'v4')) AS test_table(\"c1\",\"c2\")"
 
     results = list(transacted_postgresql_db.connection.execute(patched))
     assert results == [('v1', None), (None, 'v4')]

--- a/pgmock/tests/test_interface.py
+++ b/pgmock/tests/test_interface.py
@@ -62,8 +62,8 @@ def test_statement(query, start, end, expected):
         [pgmock.patch(pgmock.table('b'), [[1]], ['c1']),
          pgmock.patch(pgmock.table('c'), [[1]], ['c1'])],
         (
-            'select * from a; select * from  (VALUES (1)) AS b(c1);'
-            ' select * from  (VALUES (1)) AS c(c1)'
+            'select * from a; select * from  (VALUES (1)) AS b("c1");'
+            ' select * from  (VALUES (1)) AS c("c1")'
         )
     ),
     (
@@ -72,8 +72,8 @@ def test_statement(query, start, end, expected):
             pgmock.table('b'), [[1]], ['c1']).patch(
                 pgmock.table('c'), [[1]], ['c1'])],
         (
-            'select * from a; select * from  (VALUES (1)) AS b(c1);'
-            ' select * from  (VALUES (1)) AS c(c1)'
+            'select * from a; select * from  (VALUES (1)) AS b("c1");'
+            ' select * from  (VALUES (1)) AS c("c1")'
         )
     ),
     pytest.mark.xfail((
@@ -233,18 +233,18 @@ def test_nested_selection(transacted_postgresql_db, sql, selector):
     (
         'select * from t1 union all select * from t1',
         pgmock.patch(pgmock.table('t1')[0], [('val1.1',), ('val1.2',)], ['c1']),
-        "select * from  (VALUES ('val1.1'),('val1.2')) AS t1(c1) union all select * from t1"
+        "select * from  (VALUES ('val1.1'),('val1.2')) AS t1(\"c1\") union all select * from t1"
     ),
     (
         'select * from t1 union all select * from t1',
         pgmock.patch(pgmock.table('t1')[1], [('val1.1',), ('val1.2',)], ['c1']),
-        "select * from t1 union all select * from  (VALUES ('val1.1'),('val1.2')) AS t1(c1)"
+        "select * from t1 union all select * from  (VALUES ('val1.1'),('val1.2')) AS t1(\"c1\")"
     ),
     (
         'select * from t1 union all select * from t1',
         pgmock.patch(pgmock.table('t1')[:], [('val1.1',), ('val1.2',)], ['c1']),
-        ("select * from  (VALUES ('val1.1'),('val1.2')) AS t1(c1) union all"
-         " select * from  (VALUES ('val1.1'),('val1.2')) AS t1(c1)")
+        ("select * from  (VALUES ('val1.1'),('val1.2')) AS t1(\"c1\") union all"
+         " select * from  (VALUES ('val1.1'),('val1.2')) AS t1(\"c1\")")
     ),
     (
         'insert into a select * from t; insert into a select * from t',
@@ -259,20 +259,20 @@ def test_nested_selection(transacted_postgresql_db, sql, selector):
     (
         'select * from (select * from t) bb;select * from (select * from t) bb;',
         pgmock.patch(pgmock.subquery('bb'), [('val1.1',), ('val1.2',)], ['c1']),
-        ("select * from  (VALUES ('val1.1'),('val1.2')) AS bb(c1);"
-         "select * from  (VALUES ('val1.1'),('val1.2')) AS bb(c1);")
+        ("select * from  (VALUES ('val1.1'),('val1.2')) AS bb(\"c1\");"
+         "select * from  (VALUES ('val1.1'),('val1.2')) AS bb(\"c1\");")
     ),
     (
         'create table a as (select * from t); create table a as (select * from t)',
         pgmock.patch(pgmock.create_table_as('a'), [('val1.1',), ('val1.2',)], ['c1']),
-        ("create table a as SELECT * FROM (VALUES ('val1.1'),('val1.2')) AS pgmock(c1);"
-         " create table a as SELECT * FROM (VALUES ('val1.1'),('val1.2')) AS pgmock(c1)")
+        ("create table a as SELECT * FROM (VALUES ('val1.1'),('val1.2')) AS pgmock(\"c1\");"
+         " create table a as SELECT * FROM (VALUES ('val1.1'),('val1.2')) AS pgmock(\"c1\")")
     ),
     (
         'WITH bb AS (SELECT * FROM a), bb AS (SELECT * FROM c)',
         pgmock.patch(pgmock.cte('bb'), [('val1.1',), ('val1.2',)], ['c1']),
-        ("WITH bb AS ( SELECT * FROM (VALUES ('val1.1'),('val1.2')) AS pgmock(c1)),"
-         " bb AS ( SELECT * FROM (VALUES ('val1.1'),('val1.2')) AS pgmock(c1))")
+        ("WITH bb AS ( SELECT * FROM (VALUES ('val1.1'),('val1.2')) AS pgmock(\"c1\")),"
+         " bb AS ( SELECT * FROM (VALUES ('val1.1'),('val1.2')) AS pgmock(\"c1\"))")
     )
 ])
 def test_multiple_match_patching(transacted_postgresql_db, sql, selector, expected_sql):
@@ -391,7 +391,7 @@ def test_create_table_as_patched(query, table):
     """Tests patching an "create table as" statement from a query"""
     sql = pgmock.sql(query, pgmock.create_table_as(table).patch(rows=[(1,), (2,)],
                                                                 cols=['a']))
-    assert sql == 'create table a as SELECT * FROM (VALUES (1),(2)) AS pgmock(a)'
+    assert sql == 'create table a as SELECT * FROM (VALUES (1),(2)) AS pgmock("a")'
 
 
 @pytest.mark.parametrize('query, selectors, expected', [

--- a/pgmock/tests/test_render.py
+++ b/pgmock/tests/test_render.py
@@ -48,7 +48,9 @@ def test_gen_values_alias_w_null():
     rows = [(1, '1', 1.1), (2, '2', 2.2)]
     cols = ['a', 'b', 'c', 'fill']
     expression = pgmock.render._gen_values(rows, cols, 'd')
-    assert expression == "(VALUES (1,'1',1.1,null),(2,'2',2.2,null)) AS d(\"a\",\"b\",\"c\",\"fill\")"
+    assert (
+        expression == "(VALUES (1,'1',1.1,null),(2,'2',2.2,null)) AS d(\"a\",\"b\",\"c\",\"fill\")"
+    )
 
 
 @pytest.mark.parametrize('rows, cols, expected', [

--- a/pgmock/tests/test_render.py
+++ b/pgmock/tests/test_render.py
@@ -48,7 +48,7 @@ def test_gen_values_alias_w_null():
     rows = [(1, '1', 1.1), (2, '2', 2.2)]
     cols = ['a', 'b', 'c', 'fill']
     expression = pgmock.render._gen_values(rows, cols, 'd')
-    assert expression == "(VALUES (1,'1',1.1,null),(2,'2',2.2,null)) AS d(a,b,c,fill)"
+    assert expression == "(VALUES (1,'1',1.1,null),(2,'2',2.2,null)) AS d(\"a\",\"b\",\"c\",\"fill\")"
 
 
 @pytest.mark.parametrize('rows, cols, expected', [

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -10,6 +10,8 @@ flake8==3.5.0
 psycopg2==2.7.3.2
 pycodestyle<2.4.0  # for compatibility with flake8
 pylint==1.8.2
-pytest==3.4.0
+pytest==3.4.2
 pytest-mock==1.6.3
 pytest-pgsql==1.0.1
+# https://github.com/pytest-dev/pytest/issues/5903
+attrs==19.1 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -10,8 +10,8 @@ flake8==3.5.0
 psycopg2==2.7.3.2
 pycodestyle<2.4.0  # for compatibility with flake8
 pylint==1.8.2
-pytest==3.4.2
-pytest-mock==1.6.3
+pytest==3.5.1
+pytest-mock==1.9.0
 pytest-pgsql==1.0.1
 # https://github.com/pytest-dev/pytest/issues/5903
 attrs==19.1 


### PR DESCRIPTION
A table from Parser uses Postgres preserved keywords as column name, e.g. "group" [example](https://github.com/CloverHealth/clover_pipeline/blob/master/clover_specifications/parsers/ciox/chart_data_extract_sy2018/specification.yaml#L116)

Somehow a CTF pipeline depends on this table. When @brotherko writes test case for that pipeline using `get_pgmock_patch()`, he got syntax error due to that reserved keyword column.

This PR is to escape all column name in an "alias".