### PR TITLE
Add support for rendering a python list and tuple as postgres Array

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -18,3 +18,7 @@ jupyter==1.0.0
 # to install tox in the environment created by tox. It won't get used.
 tox==2.9.1
 tox-pyenv==1.1.0
+
+# Pin this version. otherwise will install 20.x.y which breaks the
+# dependencies.
+virtualenv==16.7.10

--- a/pgmock/render.py
+++ b/pgmock/render.py
@@ -233,7 +233,6 @@ def _to_sql_value(val, col_type=None):
 def _row_to_sql_values(row, col_types):
     """Serializes an entire row to a Postgres VALUES list, filling in nulls for
        any columns that don't exist in the row"""
-    # import pdb; pdb.set_trace()
     if col_types and len(col_types) > len(row):
         row = list(row) + [None] * (len(col_types) - len(row))
 
@@ -290,7 +289,6 @@ def _gen_values(rows, cols=None, alias=None, select_all_from=False):
     """
     # Postgres VALUES lists cannot syntactically handle empty lists. Instead,
     # make an empty row and limit the results to 0
-    # import pdb; pdb.set_trace()
     empty_values = False if rows else True
     rows = [[]] if not rows else rows
     cols = cols or []

--- a/pgmock/render.py
+++ b/pgmock/render.py
@@ -289,7 +289,7 @@ def _gen_values(rows, cols=None, alias=None, select_all_from=False):
     """
     # Postgres VALUES lists cannot syntactically handle empty lists. Instead,
     # make an empty row and limit the results to 0
-    empty_values = False if rows else True
+    empty_values = not rows
     rows = [[]] if not rows else rows
     cols = cols or []
     col_types = [None if '::' not in col else col.split('::')[1] for col in cols]

--- a/pgmock/render.py
+++ b/pgmock/render.py
@@ -187,6 +187,10 @@ def _get_end_statement(sql, start):
     return len(sql) if found == -1 else found
 
 
+def _render_list_or_tuple(list_or_tuple):
+    return "ARRAY[ %s ]" % ",".join(_to_sql_value(ele) for ele in list_or_tuple)
+
+
 def _to_sql_value(val, col_type=None):
     """Serializes a value into a Postgres VALUE string"""
     PG_VALUE_SERIALIZERS = {
@@ -195,6 +199,8 @@ def _to_sql_value(val, col_type=None):
         int: str,
         float: str,
         dict: lambda v: "'%s'" % json.dumps(v).replace("'", "''"),
+        list: _render_list_or_tuple,
+        tuple: _render_list_or_tuple,
         dt.datetime: lambda v: "'%s'" % v.isoformat(),
         dt.date: lambda v: "'%s'" % v.isoformat(),
         dt.time: lambda v: "'%s'" % v.isoformat(),
@@ -227,6 +233,7 @@ def _to_sql_value(val, col_type=None):
 def _row_to_sql_values(row, col_types):
     """Serializes an entire row to a Postgres VALUES list, filling in nulls for
        any columns that don't exist in the row"""
+    # import pdb; pdb.set_trace()
     if col_types and len(col_types) > len(row):
         row = list(row) + [None] * (len(col_types) - len(row))
 
@@ -283,6 +290,7 @@ def _gen_values(rows, cols=None, alias=None, select_all_from=False):
     """
     # Postgres VALUES lists cannot syntactically handle empty lists. Instead,
     # make an empty row and limit the results to 0
+    # import pdb; pdb.set_trace()
     empty_values = False if rows else True
     rows = [[]] if not rows else rows
     cols = cols or []

--- a/pgmock/tests/test_render.py
+++ b/pgmock/tests/test_render.py
@@ -24,7 +24,34 @@ TEST_UUID_STR = '754b2b75-96fb-4fcd-b719-adfe7ab45f11'
     ([({'my': 'json'},)], "VALUES ('{\"my\": \"json\"}'::JSON)"),
     ([({"my": "quo'te"},)], "VALUES ('{\"my\": \"quo''te\"}'::JSON)"),
     ([(uuid.UUID(TEST_UUID_STR),)], "VALUES ('{}'::UUID)".format(TEST_UUID_STR)),
-    pytest.mark.xfail(([(object(),)], None), raises=pgmock.exceptions.ValueSerializationError)
+    pytest.mark.xfail(([(object(),)], None), raises=pgmock.exceptions.ValueSerializationError),
+    pytest.param(
+        [
+            [  # 1st row
+                [1, 2, 3], # 1st col is an array
+            ]
+        ],
+        "VALUES (ARRAY[ 1,2,3 ])",
+        id="render a list"
+    ),
+    pytest.param(
+        [
+            [  # 1st row
+                (1, 2, 3), # 1st col is an tuple
+            ]
+        ],
+        "VALUES (ARRAY[ 1,2,3 ])",
+        id="render a tuple"
+    ),
+    pytest.param(
+        [
+            [  # 1st row
+                ["1", "2", "3"], # 1st col is an array
+            ]
+        ],
+        "VALUES (ARRAY[ '1','2','3' ])",
+        id="render a list of string"
+    ),
 ])
 def test_gen_values_list(rows, expected):
     """Tests generating a VALUES list with pgmock.render._gen_values"""

--- a/pgmock/tests/test_render.py
+++ b/pgmock/tests/test_render.py
@@ -28,7 +28,7 @@ TEST_UUID_STR = '754b2b75-96fb-4fcd-b719-adfe7ab45f11'
     pytest.param(
         [
             [  # 1st row
-                [1, 2, 3], # 1st col is an array
+                [1, 2, 3],  # 1st col is an array
             ]
         ],
         "VALUES (ARRAY[ 1,2,3 ])",
@@ -37,7 +37,7 @@ TEST_UUID_STR = '754b2b75-96fb-4fcd-b719-adfe7ab45f11'
     pytest.param(
         [
             [  # 1st row
-                (1, 2, 3), # 1st col is an tuple
+                (1, 2, 3),  # 1st col is an tuple
             ]
         ],
         "VALUES (ARRAY[ 1,2,3 ])",
@@ -46,7 +46,7 @@ TEST_UUID_STR = '754b2b75-96fb-4fcd-b719-adfe7ab45f11'
     pytest.param(
         [
             [  # 1st row
-                ["1", "2", "3"], # 1st col is an array
+                ["1", "2", "3"],  # 1st col is an array
             ]
         ],
         "VALUES (ARRAY[ '1','2','3' ])",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 # Requirements needed for running the test suite.
-astroid==1.6.1
+astroid
 coverage==4.4.2
 flake8-bugbear==17.12.0; python_version>'3.4'
 flake8-comprehensions==1.4.1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,7 +9,7 @@ flake8-mutable==1.2.0
 flake8==3.5.0
 psycopg2==2.7.3.2
 pycodestyle<2.4.0  # for compatibility with flake8
-pylint==1.8.2
+pylint==2.6.0
 pytest==3.5.1
 pytest-mock==1.9.0
 pytest-pgsql==1.0.1


### PR DESCRIPTION
# Main update

convert python list and tuple to postgres array.

# Other update

1. updated pylint to use isort5
1. because of (1), also need to unpin/pin other libraries.
1. because pylint upgrade, also need to update the "unrelated" code.